### PR TITLE
Restore bytedance implementation.

### DIFF
--- a/llm_unlearn_ucl/parse_args.py
+++ b/llm_unlearn_ucl/parse_args.py
@@ -120,9 +120,9 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--wandb_log_feq",
+        "--wandb_log_freq",
         type=int,
-        default=50,
+        default=1,
         help="The logging frequency for wandb to upload data",
     )
 

--- a/llm_unlearn_ucl/unlearn_harm.py
+++ b/llm_unlearn_ucl/unlearn_harm.py
@@ -180,7 +180,7 @@ def run_training_batch(
 
     # NOTE: backwardnd optimisation is done outside of this function in the
     # training loop for gradient accumulation compatibility.
-    if bool(args.wandb_log) and (idx % args.wandb_log_feq == 0):
+    if bool(args.wandb_log) and (idx % args.wandb_log_freq == 0):
         wandb.log(
             {
                 "batch": idx,


### PR DESCRIPTION
Harmful dataloader is now capped to have the same length as truthful QA when running the **bytedance** training loop.