### PR TITLE
feat: allow save_every for batch unlearning.

### DIFF
--- a/llm_unlearn_ucl/unlearn_harm.py
+++ b/llm_unlearn_ucl/unlearn_harm.py
@@ -473,7 +473,7 @@ def main(args) -> None:
                     lr_scheduler.step()
                 optimizer.zero_grad()
 
-                if args.sequential == 1:
+                if args.sequential == 1 and epoch_num % args.save_every == 0:
                     # NOTE: Batch unlearning, save for every epoch
                     model_tokenizer_save_dir = Path(
                         os.path.join(args.model_save_dir, f"idx_{epoch_num}")


### PR DESCRIPTION
use `--save_every` to specify the frequency at which checkpoints are saved for batch unlearning.