### PR TITLE
Log epochs (Important), please read

### DIFF
--- a/llm_unlearn_ucl/unlearn_harm.py
+++ b/llm_unlearn_ucl/unlearn_harm.py
@@ -192,6 +192,7 @@ def run_training_batch(
         wandb.log(
             {
                 "batch": idx,
+                "epoch": epoch,
                 "samples_count": samples_count,
                 "bad_loss": -bad_loss,
                 "normal_loss": normal_loss,


### PR DESCRIPTION
Atm we can only log loss against sample count/iteration number, but this means that if physical batch < actual batch, you get plots like this (at accumulation steps, and then 1 at the end (lower) which is the actual divided val)
![image](https://github.com/Adamliu1/SNLP_GCW/assets/26546660/2be770fc-89c3-45e0-9062-94842d513958)


with epoch count:
![image](https://github.com/Adamliu1/SNLP_GCW/assets/26546660/d6318cd2-43cb-4057-a1a8-0bfccb85805a)
