### PR TITLE
Avoid accessing evaluation.json before creating.

### DIFF
--- a/eval_harmfulness/evaluate_outputs.py
+++ b/eval_harmfulness/evaluate_outputs.py
@@ -19,9 +19,7 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-
 import pandas as pd
-
 from evaluation_scripts.moderation import QAModeration
 from evaluation_scripts.parse_args import parse_arguments
 
@@ -116,9 +114,11 @@ def main() -> None:
 
         for line, pred in zip(data, predictions):
             line["flagged"] = {"QAModeration": pred["flagged"]}
-
-    with open(os.path.join(args.output_dir, "evaluation.json"), encoding="utf-8") as f:
-        data = json.load(f)
+    else:
+        with open(
+            os.path.join(args.output_dir, "evaluation.json"), encoding="utf-8"
+        ) as f:
+            data = json.load(f)
 
     model_names_set = set([line["model"] for line in data])
     model_names = sorted(model_names_set, key=lambda x: int(x.split("_")[1]))


### PR DESCRIPTION
`evaluation.json` is created after running `evaluate_output.py`. It should only be accessed if `use_existing_evaluation` is true because otherwise the json wouldn't exist.