### PR TITLE
Fixed mathqa dataloader for seq and batch unlearning and integrate it…

### DIFF
--- a/llm_unlearn_ucl/unlearn_harm.py
+++ b/llm_unlearn_ucl/unlearn_harm.py
@@ -28,7 +28,6 @@ from typing import List
 # Added
 import numpy as np
 import torch
-import wandb
 from accelerate import Accelerator
 from datasets import load_dataset
 from parse_args import parse_args
@@ -45,6 +44,8 @@ from utils import (
     get_rand_ans_loss,
     get_truthfulQA_answers_plaintext,
 )
+
+import wandb
 
 
 def set_seed(seed_num: int) -> None:
@@ -349,8 +350,8 @@ def main(args) -> None:
         )
 
         # TODO: Decide the appropriate prefix for the dataset
-        question_prefix_str = "### Question:"
-        answer_prefix_str = "### Answer:"
+        question_prefix_str = "Problem:"
+        answer_prefix_str = "rationale:"
     else:
         print(f"Unlearning dataset not known! dataset: {args.unlearning_dataset}")
         return

--- a/llm_unlearn_ucl/unlearn_harm.py
+++ b/llm_unlearn_ucl/unlearn_harm.py
@@ -313,16 +313,44 @@ def main(args) -> None:
         question_prefix_str = "### Question:"
         answer_prefix_str = "### Answer:"
 
-    elif args.unlearning_dataset == "math_qa":
-        assert (
-            False
-        ), "Mathqa temporarirly disabled - requries implementing returning a List of Datasets for sequential unlearning with equal sizes!"
-        train_dataset = load_dataset("math_qa", split="train")
-        train_bad_loader = create_mathqa_dataloader_from_dataset(
-            tokenizer, train_dataset, batch_size=args.batch_size
+    elif args.unlearning_dataset == "allenai/math_qa":
+        full_bad_dataset = load_dataset("allenai/math_qa", split="train")
+        if args.shuffle_seed:
+            # shuffle the dataset with a given seed for reproducibility
+            full_bad_dataset = full_bad_dataset.shuffle(seed=args.shuffle_seed)
+        if args.sequential > 0:
+            # NOTE: sequential/batch unlearning using sliced dataset.
+            train_bad_dataset = full_bad_dataset.select(range(args.samples_count))
+        else:
+            # NOTE: full dataset like bytedance.
+            train_bad_dataset = full_bad_dataset
+
+        Path(args.samples_save_dir).mkdir(exist_ok=True)
+        bad_sample_path = f"{args.samples_save_dir}/mathqa_{args.samples_count if args.sequential > 0 else 'full'}_samples.json"
+        with open(bad_sample_path, "w") as fin:
+            print(f"Writing mathqa samples to {bad_sample_path}")
+            json.dump(
+                [
+                    train_bad_dataset[i]
+                    for i in range(
+                        args.samples_count
+                        if args.sequential > 0
+                        else len(train_bad_dataset)
+                    )
+                ],
+                fin,
+            )
+
+        train_bad_loaders = create_mathqa_dataloader_from_dataset(
+            tokenizer,
+            train_bad_dataset,
+            batch_size=args.batch_size,
+            splits=max(args.sequential, 1),
         )
-        question_prefix_str = "Problem:"
-        answer_prefix_str = "rationale:"
+
+        # TODO: Decide the appropriate prefix for the dataset
+        question_prefix_str = "### Question:"
+        answer_prefix_str = "### Answer:"
     else:
         print(f"Unlearning dataset not known! dataset: {args.unlearning_dataset}")
         return

--- a/llm_unlearn_ucl/utils.py
+++ b/llm_unlearn_ucl/utils.py
@@ -20,7 +20,7 @@ from transformers import DataCollatorForLanguageModeling
 
 
 def create_mathqa_dataloader_from_dataset(
-    tokenizer, dataset, fraction=1.0, batch_size=4
+    tokenizer, dataset, fraction: float = 1.0, batch_size: int = 4, splits: int = 1
 ):
     # MathQA structure:
     """
@@ -81,11 +81,16 @@ def create_mathqa_dataloader_from_dataset(
     # Add labels and make it data loader.
     data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 
-    dataloader = torch.utils.data.DataLoader(
-        dataset, batch_size=batch_size, collate_fn=data_collator
-    )
+    dataloaders = [
+        torch.utils.data.DataLoader(
+            train_split_dataset, batch_size=batch_size, collate_fn=data_collator
+        )
+        for train_split_dataset in torch.utils.data.random_split(
+            dataset, tuple(len(dataset) // splits for i in range(splits))
+        )
+    ]
 
-    return dataloader
+    return dataloaders
 
 
 def create_pku_dataloader_from_dataset(


### PR DESCRIPTION
… into unlearn_harm.py

Changed the dataloader helper function so that it works for sequential/batch unlearning.

Still not sure about the prefixes and format of the text [here](https://github.com/Adamliu1/SNLP_GCW/blob/7f5355e3804428238a636954a85b79474ea4682a/llm_unlearn_ucl/utils.py#L50C1-L50C82). Needs review and/or experiments.