### PR TITLE
Willmish/fix beavertails eval

### DIFF
--- a/eval_harmfulness/beavertails_get_cohere_answers.py
+++ b/eval_harmfulness/beavertails_get_cohere_answers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 UCL CS SNLP Naturalnego 语言 Töötlus group
+# Copyright (C) 2024 UCL CS NLP
 #    - Szymon Duchniewicz
 #    - Yadong Liu
 #    - Andrzej Szablewski

--- a/eval_harmfulness/beavertails_get_model_answers.py
+++ b/eval_harmfulness/beavertails_get_model_answers.py
@@ -1,7 +1,6 @@
-# Copyright (C) 2024 UCL CS SNLP Naturalnego 语言 Töötlus group
+# Copyright (C) 2024 UCL CS NLP
 #    - Szymon Duchniewicz
 #    - Yadong Liu
-#    - Carmen Meinson
 #    - Andrzej Szablewski
 #    - Zhe Yu
 #
@@ -13,7 +12,7 @@ import os
 
 import torch
 from datasets import load_dataset
-from transformers import AutoTokenizer, pipeline
+from transformers import AutoTokenizer, AutoModelForCausalLM
 
 from generation_scripts.parse_args import parse_args
 from generation_scripts.generation import generate_answers
@@ -29,21 +28,21 @@ def main(args) -> None:
     else:
         device = torch.device(args.device)
     tokenizer = AutoTokenizer.from_pretrained(args.model_path, padding_side="left")
-    generator = pipeline(
-        "text-generation",
-        model=args.model_path,
-        tokenizer=tokenizer,
-        device=device,
-        batch_size=args.batch_size,
-    )
+    model = AutoModelForCausalLM.from_pretrained(args.model_path, device_map=device)
+
+    # Fix for ValueError: Pipeline(and causalLM?) with tokenizer without pad_token cannot do batching. You can try to set it with `pipe.tokenizer.pad_token_id = model.config.eos_token_id`.
+    tokenizer.pad_token_id = model.config.eos_token_id
+    model.config.pad_token_id = model.config.eos_token_id
 
     model_name = os.path.basename(args.model_path)
 
     evaluations = generate_answers(
         dataset=dataset,
-        generator=generator,
+        tokenizer=tokenizer,
+        model=model,
         batch_size=args.batch_size,
         model_name=model_name,
+        device=device,
     )
 
     # Save evaluations to JSON file

--- a/eval_harmfulness/beavertails_get_model_answers.py
+++ b/eval_harmfulness/beavertails_get_model_answers.py
@@ -32,7 +32,7 @@ def main(args) -> None:
 
     # Fix for ValueError: Pipeline(and causalLM?) with tokenizer without pad_token cannot do batching. You can try to set it with `pipe.tokenizer.pad_token_id = model.config.eos_token_id`.
     tokenizer.pad_token_id = model.config.eos_token_id
-    model.config.pad_token_id = model.config.eos_token_id
+    model.generation_config.pad_token_id = model.config.eos_token_id
 
     model_name = os.path.basename(args.model_path)
 
@@ -41,6 +41,7 @@ def main(args) -> None:
         tokenizer=tokenizer,
         model=model,
         batch_size=args.batch_size,
+        max_new_tokens=args.max_new_tokens,
         model_name=model_name,
         device=device,
     )

--- a/eval_harmfulness/evaluate_outputs.py
+++ b/eval_harmfulness/evaluate_outputs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 UCL CS SNLP Naturalnego 语言 Töötlus group
+# Copyright (C) 2024 UCL CS NLP
 #    - Szymon Duchniewicz
 #    - Yadong Liu
 #    - Andrzej Szablewski
@@ -120,13 +120,32 @@ def main() -> None:
         for line, pred in zip(data, predictions):
             line["flagged"] = {"QAModeration": pred["flagged"]}
     else:
+        log_file_names = os.listdir(args.eval_dataset)
+        assert (
+            log_file_names
+        ), f"Beep boop... no files in a directory provided ({args.eval_dataset}). Something went wrong :("
+
+        data = []
+        for file_name in log_file_names:
+            with open(os.path.join(args.eval_dataset, file_name), "r") as f:
+                data.extend(json.load(f))
         with open(
-            os.path.join(args.output_dir, "evaluation.json"), encoding="utf-8"
+            os.path.join(args.output_dir, "predictions.json"), encoding="utf-8"
         ) as f:
-            data = json.load(f)
+            predictions = json.load(f)
+        for line, pred in zip(data, predictions):
+            line["flagged"] = {"QAModeration": pred["flagged"]}
+        #with open(
+        #    os.path.join(args.output_dir, "evaluation.json"), encoding="utf-8"
+        #) as f:
+        #    data = json.load(f)
 
     model_names_set = set([line["model"] for line in data])
-    model_names = sorted(model_names_set, key=lambda x: int(x.split("_")[1]))
+    try:
+        model_names = sorted(model_names_set, key=lambda x: int(x.split("_")[1]))
+    except:
+        # model names do not contain idxs
+        model_names = list(model_names_set)
 
     with open(f"{args.output_dir}/evaluation.json", "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=4)

--- a/eval_harmfulness/evaluate_outputs.py
+++ b/eval_harmfulness/evaluate_outputs.py
@@ -121,20 +121,20 @@ def main() -> None:
             line["flagged"] = {"QAModeration": pred["flagged"]}
     else:
         # XXX: Uncomment below if evaluation.json failed to generate
-        #log_file_names = os.listdir(args.eval_dataset)
-        #assert (
+        # log_file_names = os.listdir(args.eval_dataset)
+        # assert (
         #    log_file_names
-        #), f"Beep boop... no files in a directory provided ({args.eval_dataset}). Something went wrong :("
+        # ), f"Beep boop... no files in a directory provided ({args.eval_dataset}). Something went wrong :("
 
-        #data = []
-        #for file_name in log_file_names:
+        # data = []
+        # for file_name in log_file_names:
         #    with open(os.path.join(args.eval_dataset, file_name), "r") as f:
         #        data.extend(json.load(f))
-        #with open(
+        # with open(
         #    os.path.join(args.output_dir, "predictions.json"), encoding="utf-8"
-        #) as f:
+        # ) as f:
         #    predictions = json.load(f)
-        #for line, pred in zip(data, predictions):
+        # for line, pred in zip(data, predictions):
         #    line["flagged"] = {"QAModeration": pred["flagged"]}
         with open(
             os.path.join(args.output_dir, "evaluation.json"), encoding="utf-8"

--- a/eval_harmfulness/evaluate_outputs.py
+++ b/eval_harmfulness/evaluate_outputs.py
@@ -120,25 +120,26 @@ def main() -> None:
         for line, pred in zip(data, predictions):
             line["flagged"] = {"QAModeration": pred["flagged"]}
     else:
-        log_file_names = os.listdir(args.eval_dataset)
-        assert (
-            log_file_names
-        ), f"Beep boop... no files in a directory provided ({args.eval_dataset}). Something went wrong :("
+        # XXX: Uncomment below if evaluation.json failed to generate
+        #log_file_names = os.listdir(args.eval_dataset)
+        #assert (
+        #    log_file_names
+        #), f"Beep boop... no files in a directory provided ({args.eval_dataset}). Something went wrong :("
 
-        data = []
-        for file_name in log_file_names:
-            with open(os.path.join(args.eval_dataset, file_name), "r") as f:
-                data.extend(json.load(f))
-        with open(
-            os.path.join(args.output_dir, "predictions.json"), encoding="utf-8"
-        ) as f:
-            predictions = json.load(f)
-        for line, pred in zip(data, predictions):
-            line["flagged"] = {"QAModeration": pred["flagged"]}
+        #data = []
+        #for file_name in log_file_names:
+        #    with open(os.path.join(args.eval_dataset, file_name), "r") as f:
+        #        data.extend(json.load(f))
         #with open(
-        #    os.path.join(args.output_dir, "evaluation.json"), encoding="utf-8"
+        #    os.path.join(args.output_dir, "predictions.json"), encoding="utf-8"
         #) as f:
-        #    data = json.load(f)
+        #    predictions = json.load(f)
+        #for line, pred in zip(data, predictions):
+        #    line["flagged"] = {"QAModeration": pred["flagged"]}
+        with open(
+            os.path.join(args.output_dir, "evaluation.json"), encoding="utf-8"
+        ) as f:
+            data = json.load(f)
 
     model_names_set = set([line["model"] for line in data])
     try:

--- a/eval_harmfulness/generation_scripts/generation.py
+++ b/eval_harmfulness/generation_scripts/generation.py
@@ -1,39 +1,43 @@
-# Copyright (C) 2024 UCL CS SNLP Naturalnego 语言 Töötlus group
+# Copyright (C) 2024 UCL CS NLP
 #    - Szymon Duchniewicz
 #    - Yadong Liu
-#    - Carmen Meinson
 #    - Andrzej Szablewski
 #    - Zhe Yu
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
-from torch.utils.data import DataLoader
-from transformers import Pipeline
 from datasets import Dataset
-
 from tqdm import tqdm
+# For typing:
+from torch.utils.data import DataLoader
+from torch import device as tdevice
+from transformers import  AutoTokenizer, AutoModelForCausalLM
 
 
 def generate_answers(
-    dataset: Dataset, generator: Pipeline, batch_size: int, model_name: str
+    dataset: Dataset, tokenizer: AutoTokenizer, model: AutoModelForCausalLM, batch_size: int, model_name: str, device: tdevice,
 ) -> list[dict]:
     dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
 
     evaluations = []
 
     for batch in tqdm(dataloader):
-        responses = generator(
-            batch["prompt"], max_new_tokens=512, return_full_text=False
-        )
+        inputs = tokenizer(batch["prompt"], return_tensors="pt", padding=True).to(device)
+        outputs = model.generate(**inputs, max_new_tokens=512)
+        # Slice off prompt from model generations TODO: verify all models add prompt at the generation output
+        prompt_len = inputs['input_ids'].shape[1]
+        responses = tokenizer.batch_decode(outputs[:, prompt_len:], skip_special_tokens=True)
+
         for idx, response in enumerate(responses):
             evaluations.append(
                 {
                     "prompt": batch["prompt"][idx],
-                    "response": response[0]["generated_text"],
+                    "response": response[0],
                     "model": model_name,
                     "category_id": batch["category_id"][idx].item(),
                 }
             )
+        break
 
     return evaluations

--- a/eval_harmfulness/generation_scripts/generation.py
+++ b/eval_harmfulness/generation_scripts/generation.py
@@ -9,24 +9,35 @@
 
 from datasets import Dataset
 from tqdm import tqdm
+
 # For typing:
 from torch.utils.data import DataLoader
 from torch import device as tdevice
-from transformers import  AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
 def generate_answers(
-    dataset: Dataset, tokenizer: AutoTokenizer, model: AutoModelForCausalLM, batch_size: int, max_new_tokens: int, model_name: str, device: tdevice,
+    dataset: Dataset,
+    tokenizer: AutoTokenizer,
+    model: AutoModelForCausalLM,
+    batch_size: int,
+    max_new_tokens: int,
+    model_name: str,
+    device: tdevice,
 ) -> list[dict]:
     dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
 
     evaluations = []
 
     for batch in tqdm(dataloader):
-        inputs = tokenizer(batch["prompt"], return_tensors="pt", padding=True).to(device)
+        inputs = tokenizer(batch["prompt"], return_tensors="pt", padding=True).to(
+            device
+        )
         outputs = model.generate(**inputs, max_new_tokens=max_new_tokens)
-        prompt_len = inputs['input_ids'].shape[1]
-        responses = tokenizer.batch_decode(outputs[:, prompt_len:], skip_special_tokens=True)
+        prompt_len = inputs["input_ids"].shape[1]
+        responses = tokenizer.batch_decode(
+            outputs[:, prompt_len:], skip_special_tokens=True
+        )
         for idx, response in enumerate(responses):
             evaluations.append(
                 {

--- a/eval_harmfulness/generation_scripts/parse_args.py
+++ b/eval_harmfulness/generation_scripts/parse_args.py
@@ -1,7 +1,6 @@
-# Copyright (C) 2024 UCL CS SNLP Naturalnego 语言 Töötlus group
+# Copyright (C) 2024 UCL CS NLP
 #    - Szymon Duchniewicz
 #    - Yadong Liu
-#    - Carmen Meinson
 #    - Andrzej Szablewski
 #    - Zhe Yu
 #

--- a/eval_harmfulness/generation_scripts/parse_args.py
+++ b/eval_harmfulness/generation_scripts/parse_args.py
@@ -37,8 +37,11 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--max_new_tokens", type=int, default=256, help="Number of tokens to generate per each question, on which the model is evaluated."
-        )
+        "--max_new_tokens",
+        type=int,
+        default=256,
+        help="Number of tokens to generate per each question, on which the model is evaluated.",
+    )
 
     parser.add_argument(
         "--device",

--- a/eval_harmfulness/generation_scripts/parse_args.py
+++ b/eval_harmfulness/generation_scripts/parse_args.py
@@ -37,6 +37,10 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--max_new_tokens", type=int, default=256, help="Number of tokens to generate per each question, on which the model is evaluated."
+        )
+
+    parser.add_argument(
         "--device",
         type=str,
         default=None,


### PR DESCRIPTION
Changes:
- [x] Use AutoModelForCausalLM instead of Pipeline for beavertails answer generation
- [x] Add parameter for max new tokens generated for the eval (was 512, now default 256)
- [x] Wrapped model name extraction splitting during model eval in a try except (so models that are not necessarily checkpoints with matching name (idx_{number}) can be used: https://github.com/Adamliu1/SNLP_GCW/compare/willmish/fix_beavertails_eval?expand=1#diff-fc1c306b108857d2ebbbf29e7c0e9b0ba46eb6a81f8aeb457264286a85bf5194R145