### PR TITLE
Added model answer generation and evaluation for TruthfulQA.

### DIFF
--- a/eval_harmfulness/evaluation_scripts/__init__.py
+++ b/eval_harmfulness/evaluation_scripts/__init__.py
@@ -2,3 +2,4 @@ from .moderation import *
 from .constants import *
 from .utils import *
 from .parse_args import *
+from .metrics import *

--- a/eval_harmfulness/evaluation_scripts/metrics.py
+++ b/eval_harmfulness/evaluation_scripts/metrics.py
@@ -1,0 +1,57 @@
+import re
+
+import numpy as np
+
+
+def calculate_flagged_proportion_and_agreement(data: dict) -> dict:
+    flagged_moderation = np.array(
+        [line["flagged"]["QAModeration"] for line in data], dtype=bool
+    )
+
+    return {
+        "flagged/all": flagged_moderation.mean(),
+    }
+
+
+def calculate_question_repeated_ratio(data: dict) -> dict:
+    repeated_question_count = 0
+    for line in data:
+        if line["prompt"].lower() in line["response"].lower():
+            repeated_question_count += 1
+
+    return {"repeated_question_ratio": repeated_question_count / len(data)}
+
+
+def calculate_output_quality_heuristics(data: dict) -> dict:
+    special_char_count = np.array(
+        [
+            (
+                0
+                if len(line["response"]) == 0
+                else len(re.findall("[\W]", line["response"])) / len(line["response"])
+            )
+            for line in data
+        ],
+        dtype=float,
+    )
+
+    empty_count = np.array(
+        [(1 if len(line["response"]) == 0 else 0) for line in data],
+        dtype=float,
+    )
+
+    return {
+        "special_char_count/characters_in_response": special_char_count.mean(),
+        "empty_response_ratio": empty_count.mean(),
+    }
+
+
+def calculate_response_length(data: dict) -> dict:
+    response_len = np.array(
+        [len(line["response"]) for line in data],
+        dtype=float,
+    )
+
+    return {
+        "avg_response_length": response_len.mean(),
+    }

--- a/eval_truthfulQA/evaluate_outputs.py
+++ b/eval_truthfulQA/evaluate_outputs.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2024 UCL CS NLP
+#    - Szymon Duchniewicz
+#    - Yadong Liu
+#    - Andrzej Szablewski
+#    - Zhe Yu
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+
+import json
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from evaluation_scripts.parse_args import parse_arguments
+from evaluation_scripts.metrics import (
+    calculate_question_repeated_ratio,
+    calculate_output_quality_heuristics,
+    calculate_response_length,
+)
+
+
+def plot_metrics(metrics: list[dict], output_dir: str, plot_title: str) -> None:
+    """Plot metrics."""
+    model_names = np.asarray([row["model_name"] for row in metrics])
+    # moderation = np.asarray([row["flagged/all"] for row in metrics])
+    special_chars = np.asarray(
+        [row["special_char_count/characters_in_response"] for row in metrics]
+    )
+    empty = np.asarray([row["empty_response_ratio"] for row in metrics])
+    bar_width = 0.25
+    index = np.arange(len(special_chars))
+    _, ax = plt.subplots(figsize=(8, 6), dpi=150)
+
+    avg_response_length = np.asarray([row["avg_response_length"] for row in metrics])
+    ax.bar(
+        index,
+        avg_response_length,
+        bar_width,
+        color="#FF6D60",
+        alpha=0.85,
+        zorder=2,
+    )
+
+    ax.set_xlabel("Model")
+    ax.set_ylabel("Characters")
+
+    ax_twin = ax.twinx()
+
+    ax_twin.scatter(
+        index,
+        special_chars,
+        s=100,
+        label="special chars/all chars ratio",
+        color="#00FF00",
+        alpha=0.85,
+        zorder=2,
+        marker="s",
+    )
+
+    ax_twin.scatter(
+        index,
+        empty,
+        s=100,
+        label="empty responses ratio",
+        color="#0000FF",
+        alpha=0.85,
+        zorder=2,
+    )
+
+    plt.legend(bbox_to_anchor=(0.55, -0.4), loc="lower right")
+
+    ax.grid(axis="y", color="k", alpha=0.2, zorder=1)
+
+    ax.set_xticks(index)
+    ax.set_xticklabels(model_names)
+    ax.set_xlabel("Model")
+    ax.set_ylabel("Average response length (chars.)")
+    ax.set_title(f"TruthfulQA eval: {plot_title}")
+    ax_twin.set_ylabel("Percentage (%)")
+    ax_twin.set_yticks(np.arange(0, 1, 0.1))
+    ax_twin.set_yticklabels([f"{i*10}%" for i in range(0, 10, 1)])
+    ax_twin.set_ylim(0, 1)
+
+    plt.tight_layout()
+    plt.savefig(os.path.join(output_dir, "plot.png"))
+
+
+def main() -> None:
+    args = parse_arguments()
+
+    assert (
+        args.eval_dataset is not None
+    ), "Beep boop... you need to provide path of the directory with generated answers."
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    log_file_names = os.listdir(args.eval_dataset)
+    assert (
+        log_file_names
+    ), f"Beep boop... no files in a directory provided ({args.eval_dataset}). Something went wrong :("
+
+    data = []
+    for file_name in log_file_names:
+        with open(os.path.join(args.eval_dataset, file_name), "r") as f:
+            data.extend(json.load(f))
+
+    model_names_set = set([line["model"] for line in data])
+    try:
+        model_names = sorted(model_names_set, key=lambda x: int(x.split("_")[1]))
+    except:
+        # model names do not contain idxs
+        model_names = list(model_names_set)
+
+    metrics = []
+    for model_name in model_names:
+        model_data = [line for line in data if line["model"] == model_name]
+
+        metrics.append(
+            {
+                "model_name": model_name,
+                **calculate_output_quality_heuristics(model_data),
+                **calculate_response_length(model_data),
+                **calculate_question_repeated_ratio(model_data),
+            },
+        )
+
+    # report to terminal and save to file
+    df = pd.DataFrame(metrics)
+    print(df)
+    df.to_csv(os.path.join(args.output_dir, "results.csv"), index=False)
+
+    plot_metrics(metrics, args.output_dir, "")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval_truthfulQA/evaluation_scripts/__init__.py
+++ b/eval_truthfulQA/evaluation_scripts/__init__.py
@@ -1,0 +1,2 @@
+from .parse_args import *
+from .metrics import *

--- a/eval_truthfulQA/evaluation_scripts/metrics.py
+++ b/eval_truthfulQA/evaluation_scripts/metrics.py
@@ -1,0 +1,47 @@
+import re
+
+import numpy as np
+
+
+def calculate_question_repeated_ratio(data: dict) -> dict:
+    repeated_question_count = 0
+    for line in data:
+        if line["question"].lower() in line["answer"].lower():
+            repeated_question_count += 1
+
+    return {"repeated_question_ratio": repeated_question_count / len(data)}
+
+
+def calculate_output_quality_heuristics(data: dict) -> dict:
+    special_char_count = np.array(
+        [
+            (
+                0
+                if len(line["answer"]) == 0
+                else len(re.findall("[\W]", line["answer"])) / len(line["answer"])
+            )
+            for line in data
+        ],
+        dtype=float,
+    )
+
+    empty_count = np.array(
+        [(1 if len(line["answer"]) == 0 else 0) for line in data],
+        dtype=float,
+    )
+
+    return {
+        "special_char_count/characters_in_response": special_char_count.mean(),
+        "empty_response_ratio": empty_count.mean(),
+    }
+
+
+def calculate_response_length(data: dict) -> dict:
+    response_len = np.array(
+        [len(line["answer"]) for line in data],
+        dtype=float,
+    )
+
+    return {
+        "avg_response_length": response_len.mean(),
+    }

--- a/eval_truthfulQA/evaluation_scripts/parse_args.py
+++ b/eval_truthfulQA/evaluation_scripts/parse_args.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2024 UCL CS SNLP Naturalnego 语言 Töötlus group
+#    - Szymon Duchniewicz
+#    - Yadong Liu
+#    - Andrzej Szablewski
+#    - Zhe Yu
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+import argparse
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--eval_dataset",
+        type=str,
+        help="Path to the input JSON file.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        required=True,
+        help="Where to store.",
+    )
+    return parser.parse_args()

--- a/eval_truthfulQA/generate_outputs.py
+++ b/eval_truthfulQA/generate_outputs.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2024 UCL CS NLP
+#    - Szymon Duchniewicz
+#    - Yadong Liu
+#    - Andrzej Szablewski
+#    - Zhe Yu
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+import json
+import os
+
+import torch
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+from generation_scripts.parse_args import parse_args
+from generation_scripts.generation import generate_answers
+
+
+def main(args) -> None:
+    # load dataset
+    dataset = load_dataset(args.dataset_path, "generation", cache_dir=args.cache_dir)[
+        "validation"
+    ]
+
+    # load model for eval
+    if args.device is None:
+        device = None
+    else:
+        device = torch.device(args.device)
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path, padding_side="left")
+    model = AutoModelForCausalLM.from_pretrained(args.model_path, device_map=device)
+
+    # Fix for ValueError: Pipeline(and causalLM?) with tokenizer without pad_token cannot do batching. You can try to set it with `pipe.tokenizer.pad_token_id = model.config.eos_token_id`.
+    tokenizer.pad_token_id = model.config.eos_token_id
+    model.generation_config.pad_token_id = model.config.eos_token_id
+
+    model_name = os.path.basename(args.model_path)
+
+    evaluations = generate_answers(
+        dataset=dataset,
+        tokenizer=tokenizer,
+        model=model,
+        batch_size=args.batch_size,
+        max_new_tokens=args.max_new_tokens,
+        model_name=model_name,
+        device=device,
+    )
+
+    # Save evaluations to JSON file
+    os.makedirs(args.output_dir, exist_ok=True)
+    with open(f"{args.output_dir}/evaluation_{model_name}.json", "w+") as outfile:
+        json.dump(evaluations, outfile, ensure_ascii=False, indent=4)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    main(args)

--- a/eval_truthfulQA/generation_scripts/__init__.py
+++ b/eval_truthfulQA/generation_scripts/__init__.py
@@ -1,0 +1,2 @@
+from .parse_args import *
+from .generation import *

--- a/eval_truthfulQA/generation_scripts/generation.py
+++ b/eval_truthfulQA/generation_scripts/generation.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2024 UCL CS NLP
+#    - Szymon Duchniewicz
+#    - Yadong Liu
+#    - Andrzej Szablewski
+#    - Zhe Yu
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+from datasets import Dataset
+from tqdm import tqdm
+
+# For typing:
+from torch.utils.data import DataLoader
+from torch import device as tdevice
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+
+def generate_answers(
+    dataset: Dataset,
+    tokenizer: AutoTokenizer,
+    model: AutoModelForCausalLM,
+    batch_size: int,
+    max_new_tokens: int,
+    model_name: str,
+    device: tdevice,
+) -> list[dict]:
+    dataloader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        collate_fn=lambda data: [x["question"] for x in data],
+    )
+
+    evaluations = []
+
+    for batch in tqdm(dataloader):
+        inputs = tokenizer(batch, return_tensors="pt", padding=True).to(device)
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            do_sample=True,
+            temperature=0.75,
+        )
+        prompt_len = inputs["input_ids"].shape[1]
+        responses = tokenizer.batch_decode(
+            outputs[:, prompt_len:], skip_special_tokens=True
+        )
+        for idx, response in enumerate(responses):
+            evaluations.append(
+                {
+                    "question": batch[idx],
+                    "answer": response,
+                    "model": model_name,
+                }
+            )
+
+    return evaluations

--- a/eval_truthfulQA/generation_scripts/parse_args.py
+++ b/eval_truthfulQA/generation_scripts/parse_args.py
@@ -55,7 +55,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--cache_dir",
         type=str,
-        default="./.cache_dir",
+        default="./.cache",
         help="Path to the cache directory.",
     )
 

--- a/eval_truthfulQA/generation_scripts/parse_args.py
+++ b/eval_truthfulQA/generation_scripts/parse_args.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2024 UCL CS NLP
+#    - Szymon Duchniewicz
+#    - Yadong Liu
+#    - Andrzej Szablewski
+#    - Zhe Yu
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+import argparse
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        required=True,
+        help="Path pointing to the model to evaluate. E.g. facebook/opt-1.3b.",
+    )
+
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default="truthfulqa/truthful_qa",
+        help="Path from which to load the truthfulQA dataset. By default download from HuggingFace.",
+    )
+
+    parser.add_argument(
+        "--batch_size", type=int, default=2, help="Evaluation batch size"
+    )
+
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=256,
+        help="Number of tokens to generate per each question, on which the model is evaluated.",
+    )
+
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Select the device to run this on. By default will be None (so quantised model will succeed)",
+    )
+
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="./model_generations",
+        help="Directory to which the output JSON is saved.",
+    )
+
+    parser.add_argument(
+        "--cache_dir",
+        type=str,
+        default="./.cache_dir",
+        help="Path to the cache directory.",
+    )
+
+    args = parser.parse_args()
+
+    return args


### PR DESCRIPTION
- This PR introduces evaluation of model responses for TruthfulQA in a similar manner to the beavertails eval. 
- Furthermore, it adds additional metrics (such as avg. model response length, empty response ratio, etc.) for both the beavterails and TruthfulQA evals.
- Finally, a new metric is added which measures for how many prompts the prompt has been repeated in an answer. This is particularly useful for a better understanding of the high flagged ratio of beavertails answers.

Closes #123. 