### PR TITLE
Added multiple response generation and majority voting for harmfulness eval.

### DIFF
--- a/eval_harmfulness/beavertails_get_cohere_answers.py
+++ b/eval_harmfulness/beavertails_get_cohere_answers.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 from cohere_api_key import COHERE_API_PRODUCTION_KEY
 
 
+# TODO add support for num_generations_per_prompt arg.
 def main() -> None:
     co = cohere.Client(COHERE_API_PRODUCTION_KEY)
     output_dir = "./model_generations"

--- a/eval_harmfulness/beavertails_get_model_answers.py
+++ b/eval_harmfulness/beavertails_get_model_answers.py
@@ -19,6 +19,10 @@ from generation_scripts.generation import generate_answers
 
 
 def main(args) -> None:
+    assert (
+        args.num_generations_per_prompt % 2 == 1
+    ), "The argument num_generations_per_prompt needs to be odd for majority voting to make sense."
+
     # load dataset
     dataset = load_dataset(args.dataset_path)["test"]
 
@@ -43,6 +47,7 @@ def main(args) -> None:
         batch_size=args.batch_size,
         max_new_tokens=args.max_new_tokens,
         model_name=model_name,
+        num_generations_per_prompt=args.num_generations_per_prompt,
         device=device,
     )
 

--- a/eval_harmfulness/generation_scripts/parse_args.py
+++ b/eval_harmfulness/generation_scripts/parse_args.py
@@ -57,6 +57,13 @@ def parse_args() -> argparse.Namespace:
         help="Directory to which the output JSON is saved.",
     )
 
+    parser.add_argument(
+        "--num_generations_per_prompt",
+        type=int,
+        default=5,
+        help="Number of generations per question used in majority voting.",
+    )
+
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
This PR introduces the following:
- Multiple answer generation for harmfulness eval. The number of generated answers is now set by passing the `--num_generations_per_prompt` flag to the `beavertails_get_model_answers.py` script. **The default is set to 5.**

    - **Parameter name changed!** As before, model generations are stored in a json file, however a key name has changed from `response` (previously holding a single string generation) to `responses`, now holding an array of strings.

- Majority voting is implemented in `evaluate_outputs.py`, where the beaver-dam model classifies for harmful/safe content each of the generated responses for each of the questions. To proceed with further evaluations, it selects the first generated answer with the majority class (from the ordered `responses` array). 
    - As before, the evaluations are stored in a json file, where the `response` and `flagged` fields correspond to the selected response. In addition, an array `all_responses` with all responses and corresponding classifications is stored. 

Closes: #91.