### PR TITLE
Added max sample length filter to unlearning and retaining datasets

### DIFF
--- a/llm_unlearn_ucl/parse_args.py
+++ b/llm_unlearn_ucl/parse_args.py
@@ -179,6 +179,12 @@ def parse_args() -> argparse.Namespace:
         "--num_epochs", type=int, default=100, help="Number of epochs to unlearn."
     )
     parser.add_argument(
+        "--max_sample_length",
+        type=int,
+        default=None,
+        help="Max total length (in tokens) of a sample to unlearn.",
+    )
+    parser.add_argument(
         "--no_scheduler",
         action="store_true",
         help="Set this flag to disable lr_scheduler",

--- a/llm_unlearn_ucl/unlearn_harm.py
+++ b/llm_unlearn_ucl/unlearn_harm.py
@@ -188,34 +188,6 @@ def main(args) -> None:
             num_splits=max(args.sequential, 1),
         ).get_loaders()
 
-        samples = []
-        for _, batch in enumerate(train_bad_loaders[0]):
-            for elements in batch["input_ids"]:
-                samples.append(elements.numpy())
-
-        lengths = [len(x) for x in samples]
-
-        print("Dataset tokenisation length analysis:")
-        print("Max:", max(lengths))
-        print("Mean:", sum(lengths) / len(lengths))
-        import numpy
-
-        print("75th percentile:", numpy.quantile(lengths, 0.75))
-        print("90th percentile:", numpy.quantile(lengths, 0.90))
-        print("99th percentile:", numpy.quantile(lengths, 0.99))
-
-        if args.max_sample_length is not None:
-            print(
-                f"Number of samples shorter than {args.max_sample_length} tokens: "
-                + f"{numpy.sum(numpy.less(lengths, args.max_sample_length))}/{len(lengths)} "
-                + f"({numpy.sum(numpy.less(lengths, args.max_sample_length))/len(lengths)})",
-            )
-
-        from matplotlib import pyplot as plt
-
-        plt.hist(lengths)
-        plt.show()
-
         if args.unlearning_dataset == "AgentPublic/piaf":
             question_prefix_str = "### Question:"
             answer_prefix_str = "### Réponse:"

--- a/llm_unlearn_ucl/unlearn_harm.py
+++ b/llm_unlearn_ucl/unlearn_harm.py
@@ -209,7 +209,6 @@ def main(args) -> None:
             args.retaining_dataset = "truthfulqa/truthful_qa"
         train_normal_dataset, normal_sample_path = make_dataset(
             args.retaining_dataset,
-            args.samples_count if args.sequential != -1 else None,
             args.shuffle_seed,
             save_dir=args.samples_save_dir,
         )
@@ -217,6 +216,8 @@ def main(args) -> None:
         train_normal_loaders = DataloaderConstructor(
             train_normal_dataset,
             args.retaining_dataset,
+            num_samples=None if args.sequential == -1 else args.samples_count,
+            max_sample_length=args.max_sample_length,
             batch_size=args.batch_size,
             tokenizer=tokenizer,
             num_splits=max(args.sequential, 1),


### PR DESCRIPTION
Added a way to set the maximum sample length (in tokens) for both the unlearning and retaining datasets. This was implemented to limit the GPU memory usage on longer samples.

This change introduces another argument to the `unlearn_harm.py` script: `max_sample_length`, which represents the maximum number of tokens (after adding the prompt) of a sample. Essentially, this will be the maximum dimension of a tensor that goes through the model.